### PR TITLE
Fix placeholder issue in ProjectCard

### DIFF
--- a/components/ui/projectCard.tsx
+++ b/components/ui/projectCard.tsx
@@ -22,7 +22,7 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, svgSrc, link, isSmalle
         loading="eager"
         sizes={isSmaller ? "400px" : "525px"}
         placeholder="blur"
-        blurDataURL={`data:image/svg+xml;base64,...`}
+        blurDataURL="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxIiBoZWlnaHQ9IjEiPjwvc3ZnPg=="
       />
     </div>
   </Link>


### PR DESCRIPTION
## Summary
- use a valid base64 placeholder for the Image component in `ProjectCard`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68406f4e64188328ad3c71324dcee014