### PR TITLE
Fix invalid Image placeholder

### DIFF
--- a/components/ui/projectCard.tsx
+++ b/components/ui/projectCard.tsx
@@ -21,8 +21,6 @@ const ProjectCard: React.FC<ProjectCardProps> = ({ title, svgSrc, link, isSmalle
         priority
         loading="eager"
         sizes={isSmaller ? "400px" : "525px"}
-        placeholder="blur"
-        blurDataURL={`data:image/svg+xml;base64,...`}
       />
     </div>
   </Link>


### PR DESCRIPTION
## Summary
- remove invalid blurDataURL placeholder from `ProjectCard`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'path' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6866f1670ba88328879596b35e26ddac