### PR TITLE
Remove deprecated image layout prop

### DIFF
--- a/app/projects/clubsneu/page.tsx
+++ b/app/projects/clubsneu/page.tsx
@@ -69,7 +69,6 @@ function ClubsNEUContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>
@@ -102,7 +101,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -121,7 +119,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
                 <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -130,7 +127,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
                 <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -139,7 +135,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -176,7 +171,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -201,7 +195,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
                 <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -210,7 +203,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -229,7 +221,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -248,7 +239,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
                 <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -257,7 +247,6 @@ function ClubsNEUContent() {
                     alt="ClubsNEU main interface"
                     width={1200}
                     height={675}
-                    layout="responsive"
                   />
                 </div>
               </div>
@@ -283,7 +272,6 @@ function ClubsNEUContent() {
                       alt="ClubsNEU main interface"
                       width={1200}
                       height={675}
-                      layout="responsive"
                     />
                   </div>
                   <h4 className="text-primary-color-light">
@@ -298,7 +286,6 @@ function ClubsNEUContent() {
                       alt="ClubsNEU main interface"
                       width={1200}
                       height={675}
-                      layout="responsive"
                     />
                   </div>
                   <h4 className="text-primary-color-light">
@@ -313,7 +300,6 @@ function ClubsNEUContent() {
                       alt="ClubsNEU main interface"
                       width={1200}
                       height={675}
-                      layout="responsive"
                     />
                   </div>
                   <h4 className="text-primary-color-light">

--- a/app/projects/fetchr/page.tsx
+++ b/app/projects/fetchr/page.tsx
@@ -55,7 +55,6 @@ function FetchrContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
               <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -64,7 +63,6 @@ function FetchrContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
               <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -73,7 +71,6 @@ function FetchrContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>

--- a/app/projects/linkedin/page.tsx
+++ b/app/projects/linkedin/page.tsx
@@ -85,7 +85,6 @@ function LinkedInContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>
@@ -211,7 +210,6 @@ function LinkedInContent() {
                         alt="Internal audit"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                   </div>
@@ -230,7 +228,6 @@ function LinkedInContent() {
                         alt="External audit"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                   </div>
@@ -316,7 +313,6 @@ function LinkedInContent() {
                         alt="Entry point 1"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -325,7 +321,6 @@ function LinkedInContent() {
                         alt="Entry point 2"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -334,7 +329,6 @@ function LinkedInContent() {
                         alt="Entry point 3"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                   </div>
@@ -353,7 +347,6 @@ function LinkedInContent() {
                         alt="Tone selection"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                   </div>
@@ -373,7 +366,6 @@ function LinkedInContent() {
                         alt="ClubsNEU main interface"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <div className="w-full inner-shadow-tertiary rounded-[0.375rem]">
@@ -382,7 +374,6 @@ function LinkedInContent() {
                         alt="ClubsNEU main interface"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                   </div>
@@ -433,7 +424,6 @@ function LinkedInContent() {
                         alt="Brand"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <h4 className="text-primary-color-light">
@@ -469,7 +459,6 @@ function LinkedInContent() {
                         alt="AI rewrite"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <h4 className="text-primary-color-light">
@@ -484,7 +473,6 @@ function LinkedInContent() {
                         alt="Create image"
                         width={1200}
                         height={675}
-                        layout="responsive"
                       />
                     </div>
                     <h4 className="text-primary-color-light">

--- a/app/projects/remo/page.tsx
+++ b/app/projects/remo/page.tsx
@@ -45,7 +45,6 @@ function ReMoContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>

--- a/app/projects/searchneu/page.tsx
+++ b/app/projects/searchneu/page.tsx
@@ -53,7 +53,6 @@ function SearchNEUContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>

--- a/app/projects/udemy/page.tsx
+++ b/app/projects/udemy/page.tsx
@@ -45,7 +45,6 @@ function UdemyContent() {
                   alt="ClubsNEU main interface"
                   width={1200}
                   height={675}
-                  layout="responsive"
                 />
               </div>
             </section>


### PR DESCRIPTION
## Summary
- remove `layout="responsive"` from Image tags
- clean up blank lines and ensure closing tags remain intact

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f176eb0083289b92973af45cbe0a