### PR TITLE
Adjust TabsList padding from 0.3125rem to 0.25rem

### DIFF
--- a/components/ui/tabs.tsx
+++ b/components/ui/tabs.tsx
@@ -38,7 +38,7 @@ const TabsList = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center rounded-[0.375rem] bg-fill p-[0.3125rem] shadow-inset-tertiary",
+      "inline-flex items-center justify-center rounded-[0.375rem] bg-fill p-[0.25rem] shadow-inset-tertiary",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
Updated the padding value in the TabsList component to use a smaller, more standard spacing unit.

## Changes
- Reduced `TabsList` padding from `p-[0.3125rem]` to `p-[0.25rem]` for improved visual consistency and alignment with the design system's spacing scale

## Details
This change aligns the padding with more conventional spacing values (0.25rem = 4px at 16px base font size), replacing the previous non-standard 0.3125rem value. This adjustment maintains the visual hierarchy while improving consistency with standard spacing conventions.

https://claude.ai/code/session_01DsbSH7oWxoJdCS76Vzs5ak